### PR TITLE
Add ament_index_cpp as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PROJECT_DEPENDENCIES
   tf2_geometry_msgs
   nav_msgs
   px4_msgs
+  ament_index_cpp
 )
 
 foreach(DEPENDENCY ${PROJECT_DEPENDENCIES})

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
To properly build this in Jazzy, we should add the `ament_index_cpp` as a depenency.